### PR TITLE
Update capture script: drawing caption bug

### DIFF
--- a/core/subtitle.py
+++ b/core/subtitle.py
@@ -154,7 +154,10 @@ def drawText(img, draw, msg, pos, font, size, bg_opacity):
 		else:
 			#print("may not cut")
 			while msg[nextCut] != " ":
-				nextCut += 1
+				if nextCut < (len(msg) - 1):
+					nextCut += 1
+				else:
+					break
 			#print("new cut: {}".format(nextCut))
 
 		line = msg[cut:nextCut].strip()
@@ -165,7 +168,10 @@ def drawText(img, draw, msg, pos, font, size, bg_opacity):
 			#print("overshot")
 			nextCut -= 1
 			while msg[nextCut] != " ":
-				nextCut -= 1
+				if nextCut > 0:
+					nextCut -= 1
+				else:
+					break
 			#print("new cut: {}".format(nextCut))
 
 		lastCut = nextCut


### PR DESCRIPTION
captube: fix a drawing caption bug
If the lastCut indicate a last charactor of the string, then it will be
IndexError by 'nextCut += 1'. And also if the lastCut indicate a first
charactor of the string, then it will be IndexError by 'nextCut -= 1'.
The bugs were occured well especially for the no space language like
Chinese.

Signed-off-by: Ji-Hun Kim <jihuun.k@gmail.com>